### PR TITLE
invalid order of args n, m when called test_v_f_p()

### DIFF
--- a/HW_1/Hw_1_student_version.ipynb
+++ b/HW_1/Hw_1_student_version.ipynb
@@ -275,7 +275,7 @@
     "def mean_execution_time(n, m, trials=100):\n",
     "    \"\"\"среднее время выполнения forward_pass и vectorized_forward_pass за trials испытаний\"\"\"\n",
     "    \n",
-    "    return np.array([test_v_f_p(m, n) for _ in range(trials)]).mean(axis=0)\n",
+    "    return np.array([test_v_f_p(n, m) for _ in range(trials)]).mean(axis=0)\n",
     "\n",
     "def plot_mean_execution_time(n, m):\n",
     "    \"\"\"рисует графики среднего времени выполнения forward_pass и vectorized_forward_pass\"\"\"\n",


### PR DESCRIPTION
func signature is "def test_v_f_p(n, m):", while called as "[test_v_f_p(m, n) for _ in range(trials)"